### PR TITLE
Workaround env for conda-build 2

### DIFF
--- a/content/infrastructure/install_gds_stack.yml
+++ b/content/infrastructure/install_gds_stack.yml
@@ -1,9 +1,11 @@
 # Run `conda-env create -f install_gds_stack.yml`
 name: gds
 channels:
-  - defaults
+  - ioos
   - conda-forge
 dependencies:
+  - python=2.7
+  - pip
   - bokeh
   - cartopy
   - clusterpy
@@ -15,8 +17,6 @@ dependencies:
   - mplleaflet
   - networkx
   - palettable
-  - pip
-  - python=2.7
   - qgrid
   - rasterio
   - scikit-learn
@@ -24,4 +24,3 @@ dependencies:
   - statsmodels
   - xlrd
   - xlsxwriter
-


### PR DESCRIPTION
This is a workaround that uses the `ioos` channel to provide `hdf5`. Hopefully the same `hdf5` will be available in `conda-forge` soon.
